### PR TITLE
updated the file upload title

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -88,7 +88,7 @@
         <a asp-controller="Home" asp-action="InsecureDeserialization">🐞 Insecure Deserialization</a>
         <a asp-controller="Home" asp-action="PrototypePollution">🐞 Prototype Pollution</a>
         <a asp-controller="Home" asp-action="LFI">🐞 Local File Inclusion (LFI)</a>
-        <a asp-controller="Home" asp-action="FileUpload">🐞 Dangerous File Upload (File Overwrite)</a>
+        <a asp-controller="Home" asp-action="FileUpload">🐞 Unrestricted File Upload (File Overwrite)</a>
         <a asp-controller="Home" asp-action="CommandInjection">🐞 Command Injection (RCE)</a>
         <a asp-controller="Home" asp-action="CSRF">🐞 Cross Site Request Forgery (CSRF)</a>
         <a asp-controller="Home" asp-action="SSRF">🐞 Server Side Request Forgery (SSRF)</a>


### PR DESCRIPTION
## Fix: Change Title for File Upload Vulnerability

### Description
This PR updates the title of the **File Upload Vulnerability** from:
- **Dangerous File Upload (File Overwrite)**  
to:  
- **Unrestricted File Upload (File Overwrite)**  

This change ensures consistency with the README file.

### Related Issue
Closes #10

### Changes Made
- Updated the title in the Security Vulnerability.
- Kept the 🐞 bug emoji as requested.
