### PR TITLE
Change Login button to green in BrokenAuthentication page

### DIFF
--- a/Views/Home/BrokenAuthentication.cshtml
+++ b/Views/Home/BrokenAuthentication.cshtml
@@ -27,7 +27,7 @@
         <label for="password" class="form-label">Password</label>
         <input type="password" name="password" class="form-control" required />
     </div>
-    <button type="submit" class="btn btn-primary">Login</button>
+    <button type="submit" class="btn btn-success">Login</button>
 </form>
 
 <div class="card p-4 mt-4">


### PR DESCRIPTION
This PR updates the Login button on the Broken Authentication demo page. The button’s Bootstrap class has been changed from btn btn-primary (blue) to btn btn-success (green) to match the required design. No custom CSS was added; only the Bootstrap class was updated for color consistency.