### PR TITLE
Add file emoji 📂 to Download button on LFI page (#35)

### DIFF
--- a/Views/Home/LFI.cshtml
+++ b/Views/Home/LFI.cshtml
@@ -17,10 +17,9 @@
         <!-- Vulnerable Functionality -->
         <div class="box">
             <h2>Can you download the source code of this Web Application (without using GitHub)?</h2>
-            <a asp-controller="Home" asp-action="Download" asp-route-file="AspGoatLogo.png" class="btn btn-primary">
-                Download
+            <a asp-controller="Home" asp-action="ad" asp-route-file="AspGoatLogo.png" class="btn btn-primary">
+                📂 Download
             </a>
-
         </div>
 
         <!-- Secure Coding Challenge -->


### PR DESCRIPTION
This PR resolves issue #35 by adding a file emoji 📂 to the Download button on the Local File Inclusion (LFI) page.

Changes Made
Updated the Download button text to include a file emoji 📂 for better visual clarity.

Before
Download

After
📂 Download
