### PR TITLE
Add required attribute to search input on Reflected XSS page (Fixes #47)

### DIFF
--- a/Views/Home/ReflectedXSS.cshtml
+++ b/Views/Home/ReflectedXSS.cshtml
@@ -20,7 +20,7 @@
             <h2>Vulnerable Form</h2>
             <form method="GET">
                 <label for="query">Search:</label>
-                <input type="text" name="query" id="query"><br/>
+                <input type="text" name="query" id="query" required><br/>
                 <button class="btn btn-success" type="submit">Submit</button>
             </form>
             <br/>


### PR DESCRIPTION
This PR adds a `required` attribute to the search input field on the Reflected XSS page.  
This prevents users from submitting the form with an empty search field.

Fixes #47.
