### PR TITLE
Fix: Changed dark mode text color to match .NET theme (#5a2a9c)

### DIFF
--- a/Views/Home/PrototypePollution.cshtml
+++ b/Views/Home/PrototypePollution.cshtml
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="~/css/app.css" />
     <style>
         :root { --bg: #fff; --fg: #111; }
-        [data-theme="dark"] { --bg: #111; --fg: lime; }
+        [data-theme="dark"] { --bg: #111; --fg: #5a2a9c; }
         body { background: var(--bg); color: var(--fg); }
     </style>
 </head>


### PR DESCRIPTION
Description:
Changed dark mode text color from lime to #5a2a9c in PrototypePollution.cshtml.
This ensures consistency with the official .NET color theme.

Steps to Verify Fix:
Navigate to Prototype Pollution Lab.
Click Toggle Theme button.
In dark mode, the text color should now appear as purple (#5a2a9c) instead of lime.

Video Demo:
I have attached a short video demonstration showing the fix in action.

https://github.com/user-attachments/assets/c079042b-bd52-4f08-a641-636115247aca



Linked Issue:
Fixes #17