### PR TITLE
Add required attribute to email input in CSRF pagefix: add required attribute to email input in CSRF page

### DIFF
--- a/Views/Home/CSRF.cshtml
+++ b/Views/Home/CSRF.cshtml
@@ -20,7 +20,7 @@
             <form method="POST">
                 <label for="email">Email:</label>
                 <input type="hidden" name="id" value="1">
-                <input type="email" name="email" id="email">
+                <input type="email" name="email" id="email" class="form-control" required>
                 <br/>
                 <button class="btn btn-primary" type="submit">Submit</button>
             </form>


### PR DESCRIPTION
## Description 📝
Hi @Soham7-dev! 

I've added the `required` attribute to the email input field in the CSRF page as requested in your issue.

## Changes Made 🔧  
- ✅ Added `required` attribute to email input field in `/Views/Home/CSRF.cshtml`
- ✅ This ensures users MUST fill in their email before submitting the form
- ✅ Improves client-side validation and user experience

## Testing ✅
- [x] Verified the `required` attribute is properly added
- [x] HTML syntax is correct

Thank you for the opportunity to contribute to AspGoat! 🚀

Fixes the issue regarding email input validation in CSRF demo page.
