### PR TITLE
fix(view): remove unnecessary 'form-control' class from CSRF email input (closes #62)

### DIFF
--- a/Views/Home/CSRF.cshtml
+++ b/Views/Home/CSRF.cshtml
@@ -20,7 +20,7 @@
             <form method="POST">
                 <label for="email">Email:</label>
                 <input type="hidden" name="id" value="1">
-                <input type="email" name="email" id="email" class="form-control" required>
+                    <input type="email" name="email" id="email" required>
                 <br/>
                 <button class="btn btn-primary" type="submit">Submit</button>
             </form>


### PR DESCRIPTION
Closes #62

### Summary
Removed the unnecessary `form-control` class from the Email input on the CSRF page.

### Change
- Edited `Views/Home/CSRF.cshtml` to drop `form-control`.

### How I tested
- Verified the page still renders correctly with default input style.
- No related CSS/JS/docs required updates.

### Notes
Minimal, single-file change. Ready for review.
