### PR TITLE
fix: wrap 'development' with anchor link to GitHub Discussion #78.

### DIFF
--- a/Views/Home/FileUpload.cshtml
+++ b/Views/Home/FileUpload.cshtml
@@ -39,7 +39,7 @@
         <button class="btn btn-success">Reset</button>
     </div>
 
-    <h6 style="text-align: center; margin: 40px;">Note: The Reset feature is currently under development. If you have messed up the application while completing this challenge, please clone the app again from Github. Once defaced, you can copy the original content again from the Github repo. If you are using docker, stop and remove the container and start it again.</h6>
+    <h6 style="text-align: center; margin: 40px;">Note: The Reset feature is currently under <a href="https://github.com/OWASP/AspGoat/discussions/78" target="_blank" rel="noopener noreferrer"> development</a>. If you have messed up the application while completing this challenge, please clone the app again from Github. Once defaced, you can copy the original content again from the Github repo. If you are using docker, stop and remove the container and start it again.</h6>
 
     <h6 style="margin: 25px;">More Information:</h6>
     <ul>


### PR DESCRIPTION
### Description
Wrapped the word **“development”** in `/Views/Home/FileUpload.cshtml` 

https://github.com/Soham7-dev/AspGoat/blob/d1cd3df58a08267bf2e3e25bb65100815fa7d091/Views/Home/FileUpload.cshtml#L42

with a link to the GitHub Discussion:

🔗 [Hard Reset functionality for AspGoat #78](https://github.com/OWASP/AspGoat/discussions/78)

### Changes Made
- Added `<a>` tag around the “development” word.
- Opens in a new tab using `target="_blank"` and `rel="noopener noreferrer"` for security.

### Why
Helps users navigate directly to the relevant discussion about the Hard Reset feature while keeping accessibility and safe link behavior.

Closes #133 🌻 !
Thank you!!.....
