### PR TITLE
Move link icon inside anchor on Login page

### DIFF
--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -98,10 +98,8 @@
     </form>
 
     <div class="footer-link" style="display: flex; align-items: center; gap: 6px;">
-        <a href="https://owasp.org/www-project-aspgoat/" target="_blank" style="text-decoration: none; color: inherit;">
-            AspGoat — An OWASP Project
-        </a>
-        <img src="/expand-arrows.png" alt="Link icon" style="width: 16px; height: 16px;"/>
+        <a href="https://owasp.org/www-project-aspgoat/" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: inherit; display: inline-flex; align-items: center; gap: 6px;"> 
+        <span>AspGoat — An OWASP Project</span> <img src="/expand-arrows.png" alt="" style="width: 16px; height: 16px;" /> </a>
     </div>
 
 </body>


### PR DESCRIPTION
What: Updated Views/Account/Login.cshtml so the external‑link icon sits inside the anchor with the label; 

Why: Makes the icon clickable with the text and meets the issue’s requirement; improves accessibility and user experience.​

Testing: Ran locally at http://localhost:5073/, verified that both text and icon open the OWASP AspGoat page in a new tab