### PR TITLE
Feat: add link icon next to ‘development’ on Unrestricted File Upload page.

### DIFF
--- a/Views/Home/FileUpload.cshtml
+++ b/Views/Home/FileUpload.cshtml
@@ -39,7 +39,9 @@
         <button class="btn btn-success">Reset</button>
     </div>
 
-    <h6 style="text-align: center; margin: 40px;">Note: The Reset feature is currently under <a href="https://github.com/OWASP/AspGoat/discussions/78" target="_blank" rel="noopener noreferrer"> development</a>. If you have messed up the application while completing this challenge, please clone the app again from Github. Once defaced, you can copy the original content again from the Github repo. If you are using docker, stop and remove the container and start it again.</h6>
+    <h6 style="text-align: center; margin: 40px;">Note: The Reset feature is currently under <a href="https://github.com/OWASP/AspGoat/discussions/78" target="_blank" rel="noopener noreferrer"> development</a><img src="~/expand-arrows.png"
+         alt="external link"
+         style="width:14px; height:14px; margin-left:4px; vertical-align:middle;"/>. If you have messed up the application while completing this challenge, please clone the app again from Github. Once defaced, you can copy the original content again from the Github repo. If you are using docker, stop and remove the container and start it again.</h6>
 
     <h6 style="margin: 25px;">More Information:</h6>
     <ul>


### PR DESCRIPTION
## Description
This PR adds the link icon (`expand-arrows.png`) beside the word "development" on the Unrestricted File Upload page .

## Testing : 

- Logged in → Navigated via left panel → Unrestricted File Upload page

- Verified icon renders properly next to text

- Confirmed no layout shift or styling issues

- No build/runtime errors introduced

## Closes #141 🌻 .

Thank you !