### PR TITLE
fix: correct the development link in Unrestricted File Upload page

### DIFF
--- a/Views/Home/FileUpload.cshtml
+++ b/Views/Home/FileUpload.cshtml
@@ -39,7 +39,7 @@
         <button class="btn btn-success">Reset</button>
     </div>
 
-    <h6 style="text-align: center; margin: 40px;">Note: The Reset feature is currently under <a href="https://github.com/OWASP/AspGoat/discussions/78" target="_blank" rel="noopener noreferrer"> development</a><img src="~/expand-arrows.png"
+    <h6 style="text-align: center; margin: 40px;">Note: The Reset feature is currently under <a href="https://github.com/Soham7-dev/AspGoat/discussions/78" target="_blank" rel="noopener noreferrer"> development</a><img src="~/expand-arrows.png"
          alt="external link"
          style="width:14px; height:14px; margin-left:4px; vertical-align:middle;"/>. If you have messed up the application while completing this challenge, please clone the app again from Github. Once defaced, you can copy the original content again from the Github repo. If you are using docker, stop and remove the container and start it again.</h6>
 


### PR DESCRIPTION
Issue
The “development” word link on the Unrestricted File Upload page redirected to a 404 page.

Fix Implemented
Updated the anchor tag in /Views/Home/FileUpload.cshtml.
New link: [Hard Reset functionality for AspGoat #78](https://github.com/Soham7-dev/AspGoat/issues/78)
Ensured the link opens in a new tab and points to the correct GitHub issue.

Testing Steps
✅ Login to AspGoat
✅ Navigate to Unrestricted File Upload page
✅ Click the “development” link it correctly opens the issue page
✅ No more 404 or broken link

Linked Issue

Closes #149 