### PR TITLE
Fix: Align AI / LLM instructions vertically

### DIFF
--- a/Views/Home/LLM_Vuln.cshtml
+++ b/Views/Home/LLM_Vuln.cshtml
@@ -11,16 +11,14 @@
         <strong>Follow the instructions below in order to connect AspGoat to an LLM</strong>
     </p>
 
-    <h6 style="text-align: center; margin: 40px;">1. Install <strong><a href="https://docs.docker.com/desktop/">Docker-Desktop</a></strong> for your OS</h6>
+<h6 style="margin: 20px 0;">1. Install <strong><a href="https://docs.docker.com/desktop/">Docker-Desktop</a></strong> for your OS</h6>
 
-    <h6 style="text-align: center; margin: 40px;">2. In order to tackle the AI / LLM Labs, run Ollama server in your local machine via docker (recommended) : <a href="https://hub.docker.com/r/ollama/ollama">Ollama</a></h6>
+<h6 style="margin: 20px 0;">2. In order to tackle the AI / LLM Labs, run Ollama server in your local machine via docker (recommended) : <a href="https://hub.docker.com/r/ollama/ollama">Ollama</a></h6>
 
-    <h6 style="text-align: center; margin: 40px;">3. Install the <strong>"tinyllama:1.1b-chat"</strong> AI model inside the docker container : <strong>docker exec -it ollama ollama pull tinyllama:1.1b-chat</strong> </h6>
+<h6 style="margin: 20px 0;">3. Install the <strong>"tinyllama:1.1b-chat"</strong> AI model inside the docker container : <strong>docker exec -it ollama ollama pull tinyllama:1.1b-chat</strong> </h6>
 
-    <h6 style="text-align: center; margin: 40px;">4. (optional) If you want to use your own AI model inside Ollama server. Put the name of the AI model in appsettings.json inside <strong>aiModel</strong> parameter and install it inside the docker container using: <strong>docker exec -it ollama ollama pull &lt;name-of-ai-model&gt;</strong> </h6>
-
+<h6 style="margin: 20px 0;">4. (optional) If you want to use your own AI model inside Ollama server. Put the name of the AI model in appsettings.json inside <strong>aiModel</strong> parameter and install it inside the docker container using: <strong>docker exec -it ollama ollama pull &lt;name-of-ai-model&gt;</strong> </h6>
     <div class="row g-3">
-
         <div class="col-12 col-sm-6 col-lg-4">
             <a class="btn btn-primary w-100 py-3"
                asp-controller="LLM" asp-action="PromptInjection"


### PR DESCRIPTION
## Fix: Align AI / LLM instructions vertically

### Changes Made:
- Removed centered alignment from instruction points (1–4)
- Adjusted margin for consistent vertical spacing
- No other changes were made to the page